### PR TITLE
database_edit

### DIFF
--- a/db/migrate/20210621084612_rename_communitty_id_column_to_users.rb
+++ b/db/migrate/20210621084612_rename_communitty_id_column_to_users.rb
@@ -1,0 +1,5 @@
+class RenameCommunittyIdColumnToUsers < ActiveRecord::Migration[6.1]
+  def up
+    rename_column :users, :communitty_id, :community_id
+  end
+end

--- a/db/migrate/20210624132225_add_column_to_staff_members.rb
+++ b/db/migrate/20210624132225_add_column_to_staff_members.rb
@@ -1,0 +1,9 @@
+class AddColumnToStaffMembers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :staff_members, :desired_date_of_work, :datetime, null: true
+    add_column :staff_members, :desired_holiday_date, :datetime, null: true
+    add_column :staff_members, :the_number_of_paid_holidays, :float, null: false
+    add_column :staff_members, :possible_continuous_work, :integer, null: false
+    add_column :staff_members, :hope_for_consecutive_holidays, :integer, null: false
+  end
+end

--- a/db/migrate/20210624132225_add_column_to_staff_members.rb
+++ b/db/migrate/20210624132225_add_column_to_staff_members.rb
@@ -1,9 +1,11 @@
 class AddColumnToStaffMembers < ActiveRecord::Migration[6.1]
   def change
-    add_column :staff_members, :desired_date_of_work, :datetime, null: true
-    add_column :staff_members, :desired_holiday_date, :datetime, null: true
-    add_column :staff_members, :the_number_of_paid_holidays, :float, null: false
-    add_column :staff_members, :possible_continuous_work, :integer, null: false
-    add_column :staff_members, :hope_for_consecutive_holidays, :integer, null: false
+    change_table :staff_members, bulk: true do |t|
+      t.datetime :desired_date_of_work
+      t.datetime :desired_holiday_date
+      t.float :the_number_of_paid_holidays, null: false, default: ""
+      t.integer :possible_continuous_work, null: false, default: ""
+      t.integer :hope_for_consecutive_holidays, null: false, default: ""
+    end
   end
 end

--- a/db/migrate/20210624133524_rename_shift_calender_column_to_shift_calendars.rb
+++ b/db/migrate/20210624133524_rename_shift_calender_column_to_shift_calendars.rb
@@ -1,0 +1,5 @@
+class RenameShiftCalenderColumnToShiftCalendars < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :shift_calendars, :shift_calender, :schedule_calender
+  end
+end

--- a/db/migrate/20210624133833_rename_community_id_column_to_shift_calendars.rb
+++ b/db/migrate/20210624133833_rename_community_id_column_to_shift_calendars.rb
@@ -1,0 +1,5 @@
+class RenameCommunityIdColumnToShiftCalendars < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :shift_calendars, :community_id, :staff_members_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_24_133833) do
+ActiveRecord::Schema.define(version: 2021_06_24_142433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_21_084612) do
+ActiveRecord::Schema.define(version: 2021_06_24_133833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,8 +29,8 @@ ActiveRecord::Schema.define(version: 2021_06_21_084612) do
   end
 
   create_table "shift_calendars", force: :cascade do |t|
-    t.integer "shift_calender", null: false
-    t.bigint "community_id", null: false
+    t.integer "schedule_calender", null: false
+    t.bigint "staff_members_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -42,6 +42,11 @@ ActiveRecord::Schema.define(version: 2021_06_21_084612) do
     t.string "ward", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "desired_date_of_work"
+    t.datetime "desired_holiday_date"
+    t.float "the_number_of_paid_holidays", null: false
+    t.integer "possible_continuous_work", null: false
+    t.integer "hope_for_consecutive_holidays", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_19_135931) do
+ActiveRecord::Schema.define(version: 2021_06_21_084612) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define(version: 2021_06_19_135931) do
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "password_digest", null: false
-    t.string "communitty_id", null: false
+    t.string "community_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
## 概要
- データベースの修正をしました

## タスク内容
- staff_member テーブルのカラムの追加
- shift_calendarsのカラムをリネーム
上記2つのタスクを実施し
以下のER図の通りテーブル・カラムを実装しました
※関連付けは未実装です
<img width="902" alt="スクリーンショット 2021-06-24 22 51 58" src="https://user-images.githubusercontent.com/69076028/123274854-d4cfaa00-d53e-11eb-8413-4bc9c51289e1.png">

## 参考
- [Rails カラム名変更方法](https://qiita.com/libertyu/items/93acd8733e34b1d0a63c)
- [Railsでの複数カラムの追加・削除とまとめて行う方法](https://qiita.com/kidokoro-syusei/items/f52d6befd51ceac980e7)