### PR TITLE
各テーブル間の関連付けを実装

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,2 +1,4 @@
 class Community < ApplicationRecord
+  has_and_belongs_to_many :users
+  has_many :shift_calendars
 end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,4 +1,4 @@
 class Community < ApplicationRecord
-  has_and_belongs_to_many :users
-  has_many :shift_calendars
+  has_many :users, through: :community_users
+  has_many :shift_calendars, dependent: :delete_all
 end

--- a/app/models/shift_calendar.rb
+++ b/app/models/shift_calendar.rb
@@ -1,4 +1,4 @@
 class ShiftCalendar < ApplicationRecord
-  has_many :staff_members
+  has_many :staff_members, dependent: :nullify
   belongs_to :community
 end

--- a/app/models/shift_calendar.rb
+++ b/app/models/shift_calendar.rb
@@ -1,2 +1,4 @@
 class ShiftCalendar < ApplicationRecord
+  has_many :staff_members
+  belongs_to :community
 end

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -1,2 +1,3 @@
 class StaffMember < ApplicationRecord
+  belongs_to :shift_calendar
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,3 @@
 class User < ApplicationRecord
-  has_and_belongs_to_many :communities
+  has_many :communities, through: :community_users
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ApplicationRecord
+  has_and_belongs_to_many :communities
 end


### PR DESCRIPTION
## 概要
- ER図に沿ったテーブル間の関連付けを実装
<img width="902" alt="スクリーンショット 2021-06-24 22 51 58" src="https://user-images.githubusercontent.com/69076028/123503600-f93a9c00-d68e-11eb-9d72-c230e443814e.png">

## タスク内容
- User(多) 対 Community(多)　
   ⇨jointテーブルに(CommunitysUser)　を設定しているため
　   has_many :対象テーブル名, through: :community_usersを設定

- Community(一) 対 ShiftCallendar(多)　
  ⇨Communityが削除された場合はそれに紐づくShiftCalendarも削除されるようdependent: :delete_all
- ShiftCalendar(一) 対 StaffMember(多)
  ⇨ShiftCalendarが削除されてもそれに紐づくStaffMemberは削除されないようdependent: :nullify

## 参考
- [丁寧すぎるRails『アソシエーション』チュートリアル【幾ら何でも】【完璧にわかる】🎸](https://qiita.com/kazukimatsumoto/items/14bdff681ec5ddac26d1)
- [has_many :through関連付け](https://railsguides.jp/association_basics.html#has-many-through%E9%96%A2%E9%80%A3%E4%BB%98%E3%81%91)
- [railsガイド has_manyのオプション](https://railsguides.jp/association_basics.html#dependent)
- [ActiveRecordの:dependent使い分けまとめ【:destroy, :delete, :nullify](https://dorarep.page/articles/rails-dependent)