### PR TITLE
Feature/community test

### DIFF
--- a/spec/factories/communities.rb
+++ b/spec/factories/communities.rb
@@ -13,5 +13,6 @@
 #
 FactoryBot.define do
   factory :community do
+    communities_name { "岡山病院" }
   end
 end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -11,8 +11,22 @@
 #
 #  index_communities_on_communities_name  (communities_name) UNIQUE
 #
-# require "rails_helper"
+require "rails_helper"
 
-# RSpec.describe Community, type: :model do
-#   pending "add some examples to (or delete) #{__FILE__}"
-# end
+RSpec.describe Community, type: :model do
+  describe "コミュニティー名のバリデーションテスト" do
+    context "コミュニティー名が入力されている場合" do
+      it "登録できる" do
+        community = Community.new(communities_name: "岡山病院" )
+        expect(community.communities_name).not_to eq nil
+      end
+    end
+    context "コミュニティー名が入力されていない場合" do
+      it "登録できない" do
+        another_community = Community.new(communities_name: "" )
+        expect(another_community).to be_invalid
+        expect(another_community.errors[:communities_name]).to include("can't be blank")
+      end
+    end
+  end
+end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Community, type: :model do
       end
     end
 
-    context "コミュニティー名重複している場合" do
+    context "コミュニティー名21文字以上の場合" do
       it "登録できない" do
         community = Community.new(communities_name: "a" * 21)
         expect(community).to be_invalid

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -47,4 +47,20 @@ RSpec.describe Community, type: :model do
       end
     end
   end
+  describe "length: { maximum: 20 }" do
+    context "コミュニティー名が20文字以内の場合" do
+      it "登録できる" do
+        community = Community.create(communities_name: "a"*20 )
+        expect(community).to be_valid
+        expect(community.communities_name.length).to be <= 20
+      end
+    end
+    context "コミュニティー名重複している場合" do
+      it "登録できない" do
+        community = Community.create(communities_name: "a"*21 )
+        expect(community).to be_invalid
+        expect(community.errors[:communities_name]).to include("is too long (maximum is 20 characters)")
+      end
+    end
+  end
 end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -29,4 +29,22 @@ RSpec.describe Community, type: :model do
       end
     end
   end
+  describe "uniqueness" do
+    context "コミュニティー名が重複していない場合" do
+      it "登録できる" do
+        community = FactoryBot.create(:community)
+        another_community = Community.new(communities_name: "倉敷病院" )
+        expect(another_community).to be_valid
+        expect(another_community.communities_name).not_to eq nil
+      end
+    end
+    context "コミュニティー名重複している場合" do
+      it "登録できない" do
+        community = FactoryBot.create(:community)
+        another_community2 = Community.new(communities_name: "岡山病院" )
+        expect(another_community2).to be_invalid
+        expect(another_community2.errors[:communities_name]).to include("has already been taken")
+      end
+    end
+  end
 end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -17,47 +17,52 @@ RSpec.describe Community, type: :model do
   describe "コミュニティー名のバリデーションテスト" do
     context "コミュニティー名が入力されている場合" do
       it "登録できる" do
-        community = Community.new(communities_name: "岡山病院" )
+        community = Community.new(communities_name: "岡山病院")
         expect(community.communities_name).not_to eq nil
       end
     end
+
     context "コミュニティー名が入力されていない場合" do
       it "登録できない" do
-        another_community = Community.new(communities_name: "" )
+        another_community = Community.new(communities_name: "")
         expect(another_community).to be_invalid
         expect(another_community.errors[:communities_name]).to include("can't be blank")
       end
     end
   end
+
   describe "uniqueness" do
     context "コミュニティー名が重複していない場合" do
       it "登録できる" do
-        community = FactoryBot.create(:community)
-        another_community = Community.new(communities_name: "倉敷病院" )
+        FactoryBot.create(:community)
+        another_community = Community.new(communities_name: "倉敷病院")
         expect(another_community).to be_valid
         expect(another_community.communities_name).not_to eq nil
       end
     end
+
     context "コミュニティー名重複している場合" do
       it "登録できない" do
-        community = FactoryBot.create(:community)
-        another_community2 = Community.new(communities_name: "岡山病院" )
+        FactoryBot.create(:community)
+        another_community2 = Community.new(communities_name: "岡山病院")
         expect(another_community2).to be_invalid
         expect(another_community2.errors[:communities_name]).to include("has already been taken")
       end
     end
   end
+
   describe "length: { maximum: 20 }" do
     context "コミュニティー名が20文字以内の場合" do
       it "登録できる" do
-        community = Community.create(communities_name: "a"*20 )
+        community = Community.new(communities_name: "a" * 20)
         expect(community).to be_valid
         expect(community.communities_name.length).to be <= 20
       end
     end
+
     context "コミュニティー名重複している場合" do
       it "登録できない" do
-        community = Community.create(communities_name: "a"*21 )
+        community = Community.new(communities_name: "a" * 21)
         expect(community).to be_invalid
         expect(community.errors[:communities_name]).to include("is too long (maximum is 20 characters)")
       end


### PR DESCRIPTION
## 概要
- Communityモデルのバリデーションテスト実装

## タスク内容
### communities_name の
- presence: true, 
- uniqueness: true, 
- length: { maximum: 20 }

## 参考
- [rubocopで出たエラーの対応](https://sakanasoft.net/rubocop/#LintUselessAssignment)
```
Offenses:
spec/models/community_spec.rb:37:9: W: Lint/UselessAssignment: Useless assignment to variable - community.
        community = FactoryBot.create(:community)
        ^^^^^^^^^
```
↓
結局はそのテストの中でローカル変数(community)を使っていなかったので
FactoryBot.create(:community)だけでも良いよね？
っていうことでした😄
