### PR TITLE
修正 login に name入力 は不要なので削除

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -3,11 +3,6 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 
   <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
-  </div>
-
-  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>


### PR DESCRIPTION
## 概要
- タイトル通り

## タスク内容
- login form に name 入力は不要

## 補足
devise の機能では、email, password で log in 認証しているので、`name` は不要でした。
RV で見落としてましたmm